### PR TITLE
Stub publication workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+# Publish Typescript stubs to npm.
+
+name: Publish stubs
+
+# Prod deployments will automatically generate code into the repo
+on:
+  push
+
+permissions:
+  id-token: write
+
+jobs:
+  #----------------------------------------------
+  #               Publish stubs
+  #----------------------------------------------
+  publish-stubs:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout repo
+          uses: actions/checkout@v4
+
+        - name: Set up npm
+          uses: actions/setup-node@v4
+          with:
+            node-version: 18
+            registry-url: "https://registry.npmjs.org"
+
+        - name: Build the package
+          run: |
+            npm install
+            npm run build
+
+        - name: Publish the package
+          env:
+              NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          run: |
+            npm login
+            npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,9 @@ name: Publish stubs
 
 # Prod deployments will automatically generate code into the repo
 on:
-  push
+  push:
+    branches:
+      - main
 
 permissions:
   id-token: write

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-# Insert the following snippet into your project .npmrc
-
-@rewiringamerica:registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@rewiringamerica/rem",
-    "version": "0.4.2",
+    "version": "0.4.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@rewiringamerica/rem",
-            "version": "0.4.2",
-            "license": "Unlicense",
+            "version": "0.4.6",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@rewiringamerica/rem": "^0.4.2",
+                "@rewiringamerica/rem": "^0.4.6",
                 "bluebird": "^3.7.2",
                 "request": "^2.88.2"
             },
@@ -21,10 +21,10 @@
             }
         },
         "node_modules/@rewiringamerica/rem": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@rewiringamerica/rem/-/rem-0.4.2.tgz",
-            "integrity": "sha512-mGt4MbwWnzUaWWS7nAQZbe5rWpi5bp76dvjYcNiXOGL6wjx7LhW4Geyz9dxRpeF623FyVrP/t3liqwx0em0OOA==",
-            "license": "Unlicense",
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/@rewiringamerica/rem/-/rem-0.4.6.tgz",
+            "integrity": "sha512-iLhUuXwFWxHZCLLfNzfCfoR0xGCtDYAsbIAB03BsPxadvwwk50Wd6lCh/9Y1HS/PaAHV++J7K4P5TfAazYE7zA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "bluebird": "^3.7.2",
                 "request": "^2.88.2"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@rewiringamerica/rem",
+    "name": "@rewiringamerica/rem-testy-test",
     "version": "0.4.6",
     "description": "NodeJS client for rem",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@rewiringamerica/rem-testy-test",
+    "name": "@rewiringamerica/rem",
     "version": "0.4.6",
     "description": "NodeJS client for rem",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "author": "Rewiring America",
     "license": "Apache-2.0",
     "dependencies": {
+        "@rewiringamerica/rem": "^0.4.6",
         "bluebird": "^3.7.2",
         "request": "^2.88.2"
     },


### PR DESCRIPTION
## Summary
Mirroring the manual steps in the [API release runbook](https://github.com/rewiringamerica/dml-documents/blob/main/docs/standards/api-release-runbook.md#package-and-publish-typescript-stubs) to this automated workflow.

Since I couldn't republish to prod npm (which is why the check fails), you can see the successful publication in this test package [here](https://www.npmjs.com/package/@rewiringamerica/rem-testy-test). I'll delete it right after this PR is merged.

Some updates from the last prod publication seem to have been missed in the last prod push's regeneration, which is why some other files changed. The stubs are still useable in their current state, though.

## Useful Links
[npm automation tokens](https://docs.npmjs.com/creating-and-viewing-access-tokens)

## Checklist
- [x] Test publication contains all the information and is useable